### PR TITLE
feat(runTest): support WebPagetest scripting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ gapps.config.json
 .clasp.json
 /dist/
 /lib/
+/script.txt
 
 ### https://raw.github.com/github/gitignore/d5ce0fc1d4a677eaa60d5b8e01ac9e42ec7cfcd1/Node.gitignore
 

--- a/README.md
+++ b/README.md
@@ -35,5 +35,31 @@ TypeScript 化しました。
 
 1. スクリプトエディタから `runTest` と `getTestResults` を呼び出すトリガーを設定します。
 
+### Scriptingを行う
+
+WebPagetestのScriptingに対応しています。
+
+1. `script.txt`を`.env`と同じディレクトリに作成する
+2. `script.txt`にWebPagetestのScriptを書き込む
+
+```
+logData    0
+
+// put any urls you want to navigate
+navigate    www.aol.com
+navigate    news.aol.com
+
+logData    1
+
+// this step will get recorded
+navigate    news.aol.com/world
+```
+
+`script.txt`が指定した位置に存在する場合に自動的に`?script=<script内容>`をWebPagetestに設定します。
+
+- [Scripting - WebPagetest Documentation](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/scripting)
+
+:memo: Note: `script.txt`のファイルが存在する場合は`RUN_TEST_URL`よりも`script.txt`の内容が優先されます。
+
 ## 参考
 - [DataStudioとGASでWebPagetestの計測結果をグラフ化する | mediba Creator × Engineer Blog](http://ceblog.mediba.jp/post/154874126622/datastudio%E3%81%A8gas%E3%81%A7webpagetest%E3%81%AE%E8%A8%88%E6%B8%AC%E7%B5%90%E6%9E%9C%E3%82%92%E3%82%B0%E3%83%A9%E3%83%95%E5%8C%96%E3%81%99%E3%82%8B)

--- a/src/WebPagetest.ts
+++ b/src/WebPagetest.ts
@@ -122,17 +122,25 @@ class WebPagetest {
   public generateRunTestURL(url: string, options: Options = {}): string {
     const apiEndpoint = `${this.server}/runtest.php`
     const query = queryString.stringify({
-      url: url,
-      location: options.location || 'ec2-ap-northeast-1.3GFast',
-      runs: options.runs !== undefined ? options.runs : 1,
-      fvonly: options.fvonly !== undefined ? options.fvonly : 1,
-      video: options.video !== undefined ? options.video : 1,
-      f: options.format || 'JSON',
-      noopt: options.noOptimization !== undefined ? options.noOptimization : 1,
-      k: this.key,
-      mobile: options.mobile !== undefined ? options.mobile : 1,
-      mobileDevice: options.mobileDevice || 'Pixel',
-      lighthouse: options.lighthouse !== undefined ? options.lighthouse : 1,
+      ...{
+        url: url,
+        location: options.location || 'ec2-ap-northeast-1.3GFast',
+        runs: options.runs !== undefined ? options.runs : 1,
+        fvonly: options.fvonly !== undefined ? options.fvonly : 1,
+        video: options.video !== undefined ? options.video : 1,
+        f: options.format || 'JSON',
+        noopt: options.noOptimization !== undefined ? options.noOptimization : 1,
+        k: this.key,
+        mobile: options.mobile !== undefined ? options.mobile : 1,
+        mobileDevice: options.mobileDevice || 'Pixel',
+        lighthouse: options.lighthouse !== undefined ? options.lighthouse : 1,
+      },
+      // omit script if does not pass options.script
+      ...(options.script
+        ? {
+            script: options.script,
+          }
+        : {}),
     })
     return `${apiEndpoint}?${query}`
   }

--- a/src/__tests__/WebPagetest.test.ts
+++ b/src/__tests__/WebPagetest.test.ts
@@ -26,5 +26,24 @@ describe('WebPagetest', () => {
         `"https://www.webpagetest.org/runtest.php?url=https%3A%2F%2Fexample.com&location=ec2-ap-northeast-1%3AChrome&runs=1&fvonly=0&video=0&f=JSON&noopt=0&k=key&mobile=0&mobileDevice=iPhone5c&lighthouse=0"`
       )
     })
+    it('should return test url that include script when it has script', () => {
+      const webPagetest = new WebPagetest('key')
+      const url = webPagetest.generateRunTestURL('https://example.com', {
+        script: `logData    0
+
+// put any urls you want to navigate
+navigate    www.aol.com
+navigate    news.aol.com
+
+logData    1
+
+// this step will get recorded
+navigate    news.aol.com/world
+`,
+      })
+      expect(url).toMatchInlineSnapshot(
+        `"https://www.webpagetest.org/runtest.php?url=https%3A%2F%2Fexample.com&location=ec2-ap-northeast-1.3GFast&runs=1&fvonly=1&video=1&f=JSON&noopt=1&k=key&mobile=1&mobileDevice=Pixel&lighthouse=1&script=logData%20%20%20%200%0A%0A%2F%2F%20put%20any%20urls%20you%20want%20to%20navigate%0Anavigate%20%20%20%20www.aol.com%0Anavigate%20%20%20%20news.aol.com%0A%0AlogData%20%20%20%201%0A%0A%2F%2F%20this%20step%20will%20get%20recorded%0Anavigate%20%20%20%20news.aol.com%2Fworld%0A"`
+      )
+    })
   })
 })

--- a/src/gas.d.ts
+++ b/src/gas.d.ts
@@ -11,6 +11,7 @@ declare var process: {
     WEBPAGETEST_OPTIONS_MOBILE?: string
     WEBPAGETEST_OPTIONS_MOBILE_DEVICE?: string
     WEBPAGETEST_OPTIONS_LIGHTHOUSE?: string
+    WEBPAGETEST_OPTIONS_SCRIPT_CODE?: string
   }
 }
 
@@ -26,4 +27,5 @@ declare type Options = Partial<{
   mobile: number
   mobileDevice: string
   lighthouse: number
+  script: string
 }>

--- a/src/runTest.ts
+++ b/src/runTest.ts
@@ -23,6 +23,7 @@ global.runTest = (): void => {
   const mobile = Utils.parseNumberValue(process.env.WEBPAGETEST_OPTIONS_MOBILE)
   const mobileDevice = process.env.WEBPAGETEST_OPTIONS_MOBILE_DEVICE
   const lighthouse = Utils.parseNumberValue(process.env.WEBPAGETEST_OPTIONS_LIGHTHOUSE)
+  const script = process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE
   const wpt = new WebPagetest(key)
   const testId = wpt.test(url, {
     runs,
@@ -35,6 +36,7 @@ global.runTest = (): void => {
     mobile,
     mobileDevice,
     lighthouse,
+    script,
   })
 
   const activeSpreadsheet = SpreadsheetApp.getActiveSpreadsheet()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,12 @@
 const path = require('path')
 const Dotenv = require('dotenv-webpack')
 const GasPlugin = require('gas-webpack-plugin')
+const webpack = require('webpack')
+const fs = require('fs')
+const SCRIPT_FILE_PATH = path.join(__dirname, 'script.txt')
+const WEBPAGETEST_OPTIONS_SCRIPT_CODE = fs.existsSync(SCRIPT_FILE_PATH)
+  ? fs.readFileSync(SCRIPT_FILE_PATH, 'utf-8')
+  : undefined
 
 module.exports = {
   mode: 'none',
@@ -24,5 +30,13 @@ module.exports = {
     extensions: ['.ts', '.js'],
   },
   devtool: false,
-  plugins: [new Dotenv(), new GasPlugin()],
+  plugins: [
+    new Dotenv(),
+    new webpack.DefinePlugin({
+      'process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE': JSON.stringify(
+        WEBPAGETEST_OPTIONS_SCRIPT_CODE
+      ),
+    }),
+    new GasPlugin(),
+  ],
 }


### PR DESCRIPTION
## 変更点

- ルートディレクトリに `script.txt` が配置されている場合はscriptパラメータを追加するように
  - `script.txt` がない場合は特にしない
- `process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE`は`script.txt`の中身に置換される
  - `script.txt` がない場合は`undefined`となる
- `script.txt` はgitignoreしているのでGit管理外

fix #4 