### PR TITLE
feat(index): support menu on spreadsheet

### DIFF
--- a/src/gas.d.ts
+++ b/src/gas.d.ts
@@ -20,6 +20,7 @@ declare namespace NodeJS {
     runTest: () => void
     getTestResults: () => void
     updateColumnTitles: () => void
+    onOpen: () => void
   }
 }
 

--- a/src/getTestResults.ts
+++ b/src/getTestResults.ts
@@ -1,7 +1,7 @@
 import WebPagetest = require('./WebPagetest')
 import Utils = require('./Utils')
 
-global.getTestResults = () => {
+export const getTestResults = () => {
   const sheetName = process.env.SHEET_NAME
   if (!sheetName) {
     throw new Error('should define SHEET_NAME in .env')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+import { runTest } from './runTest'
+import { getTestResults } from './getTestResults'
+import { updateColumnTitles } from './updateColumnTitles'
+
+function onOpen() {
+  const menu = [
+    { name: 'Run test', functionName: 'runTest' },
+    { name: 'Get test results', functionName: 'getTestResults' },
+    { name: 'Update column titles', functionName: 'updateColumnTitles' },
+  ]
+  SpreadsheetApp.getActiveSpreadsheet().addMenu('gas-webpagetest', menu)
+}
+
+global.onOpen = onOpen
+global.runTest = runTest
+global.getTestResults = getTestResults
+global.updateColumnTitles = updateColumnTitles

--- a/src/runTest.ts
+++ b/src/runTest.ts
@@ -1,7 +1,7 @@
 import WebPagetest = require('./WebPagetest')
 import Utils = require('./Utils')
 
-global.runTest = (): void => {
+export const runTest = (): void => {
   const key = process.env.WEBPAGETEST_API_KEY
   if (!key) {
     throw new Error('should define WEBPAGETEST_API_KEY in .env')

--- a/src/updateColumnTitles.ts
+++ b/src/updateColumnTitles.ts
@@ -1,6 +1,6 @@
 import WebPagetest = require('./WebPagetest')
 
-global.updateColumnTitles = (): void => {
+export const updateColumnTitles = (): void => {
   const sheetName = process.env.SHEET_NAME
   if (!sheetName) {
     throw new Error('should define SHEET_NAME in .env')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,7 @@ const WEBPAGETEST_OPTIONS_SCRIPT_CODE = fs.existsSync(SCRIPT_FILE_PATH)
 module.exports = {
   mode: 'none',
   entry: {
-    runTest: './src/runTest.ts',
-    getTestResults: './src/getTestResults.ts',
-    updateColumnTitles: './src/updateColumnTitles.ts',
+    'gas-webpagetest': './src/index.ts',
   },
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
SpreadSheetのメニューに対応しました。
SpreadSheetから処理を実行できます。

![image](https://user-images.githubusercontent.com/19714/43371679-d3391db8-93d1-11e8-9e55-8595f8d287b5.png)

## 変更点

- globalを `index.ts` にまとめた
- webpackの対象を `index.ts` -> `gas-webpagetest.js` だけにした

## 破壊的な変更

- おそらく既存Time Triggerは関数が移動したことで無効化されている?

fix #8 