### PR TITLE
feat(TimeTrigger): add "setRunTestTimeTriggers" to menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,16 @@
 WEBPAGETEST_API_KEY=<your api key>
 # Test Target URL
 RUN_TEST_URL=https://example.com
-# Run Test interval(hours)
-RUN_TEST_INTERVAL_HOURS=4
+# Run Test interval
+## Set run test interval by using Google Apps Script Time-Based Trigger
+## Execute runTest function every RUN_TEST_INTERVAL
+## Example:
+## `2h`, `1h`, or `30m`
+## Limitation:
+## - Can not combine hour with minutes
+##   - `1h30m` => Error
+## - Allow to set one of `1m`, `5m`, `15m`, `30m` as minutes
+RUN_TEST_INTERVAL=30m
 # Sheet name to record
 SHEET_NAME=Sheet1
 

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
+# WebPagetest API Key
+## See https://www.webpagetest.org/getkey.php
 WEBPAGETEST_API_KEY=<your api key>
+# Test Target URL
 RUN_TEST_URL=https://example.com
+# Run Test interval(hours)
+RUN_TEST_INTERVAL_HOURS=4
+# Sheet name to record
 SHEET_NAME=Sheet1
+
 # WebPagetest Options
 # https://sites.google.com/a/webpagetest.org/docs/advanced-features/webpagetest-restful-apis
 ## Number of test runs (1-10 on the public instance)

--- a/src/TimeTrigger.ts
+++ b/src/TimeTrigger.ts
@@ -1,8 +1,10 @@
+export type EveryMinutesType = 1 | 5 | 10 | 15 | 30
+
 export class TimeTrigger {
   /**
    * @see https://developers.google.com/apps-script/reference/script/clock-trigger-builder#everyHours(Integer)
    */
-  public addNewEveryHourTrigger(functionName: string, hours: number) {
+  public addNewEveryHoursTrigger(functionName: string, hours: number) {
     ScriptApp.newTrigger(functionName)
       .timeBased()
       .everyHours(hours)
@@ -10,12 +12,19 @@ export class TimeTrigger {
   }
 
   /**
+   * EveryMinutes's value must be one of 1, 5, 10, 15 or 30.
+   */
+  public canAcceptableAsEveryMinutes(minutes: number): minutes is EveryMinutesType {
+    return [1, 5, 10, 15, 30].indexOf(minutes) !== -1
+  }
+
+  /**
    * @see https://developers.google.com/apps-script/reference/script/clock-trigger-builder#everyMinutes(Integer)
    */
-  public addNewEveryMinutesTrigger(functionName: string, minutes: 1 | 5 | 10 | 15 | 30) {
+  public addNewEveryMinutesTrigger(functionName: string, minutes: EveryMinutesType) {
     ScriptApp.newTrigger(functionName)
       .timeBased()
-      .everyMinutes(minutes) // It must be one of 1, 5, 10, 15 or 30.
+      .everyMinutes(minutes)
       .create()
   }
 

--- a/src/TimeTrigger.ts
+++ b/src/TimeTrigger.ts
@@ -1,0 +1,31 @@
+export class TimeTrigger {
+  /**
+   * @see https://developers.google.com/apps-script/reference/script/clock-trigger-builder#everyHours(Integer)
+   */
+  public addNewEveryHourTrigger(functionName: string, hours: number) {
+    ScriptApp.newTrigger(functionName)
+      .timeBased()
+      .everyHours(hours)
+      .create()
+  }
+
+  /**
+   * @see https://developers.google.com/apps-script/reference/script/clock-trigger-builder#everyMinutes(Integer)
+   */
+  public addNewEveryMinutesTrigger(functionName: string, minutes: 1 | 5 | 10 | 15 | 30) {
+    ScriptApp.newTrigger(functionName)
+      .timeBased()
+      .everyMinutes(minutes) // It must be one of 1, 5, 10, 15 or 30.
+      .create()
+  }
+
+  public deleteTrigger(functionName: string) {
+    // delete function that match functionName
+    const triggers = ScriptApp.getProjectTriggers()
+    triggers.forEach(trigger => {
+      if (trigger.getHandlerFunction() === functionName) {
+        ScriptApp.deleteTrigger(trigger)
+      }
+    })
+  }
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -31,6 +31,44 @@ class Utils {
     }
     return numberValue
   }
+
+  /**
+   * Parse time formatted value and return { type, value }
+   * Accept format: <value><unit>
+   *   - <value>: number
+   *   - <unit>: `h` or `m`
+   */
+  public static parseTimeFormat(
+    value?: string
+  ): { type: 'HOUR' | 'MINUTE'; value: number } | Error {
+    if (!value) {
+      return new Error('value is undefined')
+    }
+    const TIME_FORMATS: { type: 'HOUR' | 'MINUTE'; pattern: RegExp }[] = [
+      {
+        type: 'HOUR',
+        pattern: /^(\d+)h$/,
+      },
+      {
+        type: 'MINUTE',
+        pattern: /^(\d+)m$/,
+      },
+    ]
+    for (let i = 0; i < TIME_FORMATS.length; i++) {
+      const format = TIME_FORMATS[i]
+      if (format.pattern.test(value)) {
+        const match = value.match(format.pattern)
+        if (!match) {
+          throw new Error(`Does not parsed value: ${value}`)
+        }
+        return {
+          type: format.type,
+          value: Number(match[1]),
+        }
+      }
+    }
+    return new Error(`Does not parsed value: ${value}`)
+  }
 }
 
 export = Utils

--- a/src/__tests__/Utils.test.ts
+++ b/src/__tests__/Utils.test.ts
@@ -19,4 +19,27 @@ describe('Utils', () => {
       }).toThrow()
     })
   })
+  describe('parseTimeFormat', () => {
+    it('should return { type: HOUR } when pass 1h', () => {
+      expect(Utils.parseTimeFormat('1h')).toEqual({
+        type: 'HOUR',
+        value: 1,
+      })
+    })
+    it('should return { type: HOUR } when pass 24h', () => {
+      expect(Utils.parseTimeFormat('24h')).toEqual({
+        type: 'HOUR',
+        value: 24,
+      })
+    })
+    it('should return { type: MINUTE } when pass 30m', () => {
+      expect(Utils.parseTimeFormat('30m')).toEqual({
+        type: 'MINUTE',
+        value: 30,
+      })
+    })
+    it('should return error when pass 1h30m', () => {
+      expect(Utils.parseTimeFormat('1h30m')).toBeInstanceOf(Error)
+    })
+  })
 })

--- a/src/gas.d.ts
+++ b/src/gas.d.ts
@@ -3,7 +3,7 @@ declare namespace NodeJS {
   interface ProcessEnv {
     WEBPAGETEST_API_KEY?: string
     RUN_TEST_URL?: string
-    RUN_TEST_INTERVAL_HOURS?: string
+    RUN_TEST_INTERVAL?: string
     SHEET_NAME?: string
     WEBPAGETEST_OPTIONS_RUNS?: string
     WEBPAGETEST_OPTIONS_LOCATION?: string

--- a/src/gas.d.ts
+++ b/src/gas.d.ts
@@ -3,6 +3,7 @@ declare namespace NodeJS {
   interface ProcessEnv {
     WEBPAGETEST_API_KEY?: string
     RUN_TEST_URL?: string
+    RUN_TEST_INTERVAL_HOURS?: string
     SHEET_NAME?: string
     WEBPAGETEST_OPTIONS_RUNS?: string
     WEBPAGETEST_OPTIONS_LOCATION?: string
@@ -19,6 +20,7 @@ declare namespace NodeJS {
   export interface Global {
     runTest: () => void
     getTestResults: () => void
+    setRunTestTimeTriggers: () => void
     updateColumnTitles: () => void
     onOpen: () => void
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { runTest } from './runTest'
 import { getTestResults } from './getTestResults'
 import { updateColumnTitles } from './updateColumnTitles'
+import { setRunTestTimeTriggers } from './setRunTestTimeTriggers'
 
 function onOpen() {
   const menu = [
     { name: 'Run test', functionName: 'runTest' },
     { name: 'Get test results', functionName: 'getTestResults' },
+    { name: 'Set run test time triggers', functionName: 'setRunTestTimeTriggers' },
     { name: 'Update column titles', functionName: 'updateColumnTitles' },
   ]
   SpreadsheetApp.getActiveSpreadsheet().addMenu('gas-webpagetest', menu)
@@ -14,4 +16,5 @@ function onOpen() {
 global.onOpen = onOpen
 global.runTest = runTest
 global.getTestResults = getTestResults
+global.setRunTestTimeTriggers = setRunTestTimeTriggers
 global.updateColumnTitles = updateColumnTitles

--- a/src/setRunTestTimeTriggers.ts
+++ b/src/setRunTestTimeTriggers.ts
@@ -3,26 +3,34 @@ import { TimeTrigger } from './TimeTrigger'
 import Utils = require('./Utils')
 
 export const setRunTestTimeTriggers = (): void => {
-  const intervalHours = Utils.parseNumberValue(process.env.RUN_TEST_INTERVAL_HOURS)
-  if (intervalHours === undefined) {
-    throw new Error('should define RUN_TEST_INTERVAL_HOURS in .env')
-  }
-  if (!Number.isInteger(intervalHours)) {
-    throw new Error('RUN_TEST_INTERVAL_HOURS should be integer')
+  const parsedInterval = Utils.parseTimeFormat(process.env.RUN_TEST_INTERVAL)
+  if (parsedInterval instanceof Error) {
+    throw new Error(`should define RUN_TEST_INTERVAL with correct format in .env.
+Error: ${parsedInterval.message}`)
   }
   const timeTrigger = new TimeTrigger()
   // delete exists time trigger
   timeTrigger.deleteTrigger('runTest')
   timeTrigger.deleteTrigger('getTestResults')
   // set new Time Trigger
-  timeTrigger.addNewEveryHourTrigger('runTest', intervalHours)
+  if (parsedInterval.type === 'HOUR') {
+    if (parsedInterval.value <= 0) {
+      throw new Error(`RUN_TEST_INTERVAL hour must be larger than 0h.`)
+    }
+    timeTrigger.addNewEveryHoursTrigger('runTest', parsedInterval.value)
+  } else if (parsedInterval.type === 'MINUTE') {
+    if (!timeTrigger.canAcceptableAsEveryMinutes(parsedInterval.value)) {
+      throw new Error(`RUN_TEST_INTERVAL minutes must be one of 1m, 5m, 10m, 15m or 30m.`)
+    }
+    timeTrigger.addNewEveryMinutesTrigger('runTest', parsedInterval.value)
+  }
   // check the result every 10min or 30min
-  const getTestResultsInterval = (hour => {
-    if (hour <= 1) {
+  const getTestResultsInterval = (parsedInterval => {
+    if (parsedInterval.type === 'MINUTE') {
       return 10
     } else {
       return 30
     }
-  })(intervalHours)
+  })(parsedInterval)
   timeTrigger.addNewEveryMinutesTrigger('getTestResults', getTestResultsInterval)
 }

--- a/src/setRunTestTimeTriggers.ts
+++ b/src/setRunTestTimeTriggers.ts
@@ -1,0 +1,28 @@
+import 'core-js/modules/es6.number.is-integer'
+import { TimeTrigger } from './TimeTrigger'
+import Utils = require('./Utils')
+
+export const setRunTestTimeTriggers = (): void => {
+  const intervalHours = Utils.parseNumberValue(process.env.RUN_TEST_INTERVAL_HOURS)
+  if (intervalHours === undefined) {
+    throw new Error('should define RUN_TEST_INTERVAL_HOURS in .env')
+  }
+  if (!Number.isInteger(intervalHours)) {
+    throw new Error('RUN_TEST_INTERVAL_HOURS should be integer')
+  }
+  const timeTrigger = new TimeTrigger()
+  // delete exists time trigger
+  timeTrigger.deleteTrigger('runTest')
+  timeTrigger.deleteTrigger('getTestResults')
+  // set new Time Trigger
+  timeTrigger.addNewEveryHourTrigger('runTest', intervalHours)
+  // check the result every 10min or 30min
+  const getTestResultsInterval = (hour => {
+    if (hour <= 1) {
+      return 10
+    } else {
+      return 30
+    }
+  })(intervalHours)
+  timeTrigger.addNewEveryMinutesTrigger('getTestResults', getTestResultsInterval)
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19714/43726110-34908bde-99d9-11e8-88d7-9790230cecee.png)

![image](https://user-images.githubusercontent.com/19714/43726241-8dff5f92-99d9-11e8-92fd-66f0cdfd0b3c.png)


メニューからtime-based triggerを設定できるようにしました。
デフォルトだと 

- RunTest: ~4時間ごと~ 30分ごと
- getTestResult: ~30分ごと~ 10分ごと

になっています。~(イマイチ適正な値がわからない。。 RunTestはもうちょっと大きくてもいいかも)~

## 変更点

- Add `RUN_TEST_INTERVAL` to .env
- Add "Set run test time triggers" to menu
- Set time-based trigger from scripts


fix #16 