### PR TITLE
feat(webpagetest): add `WEBPAGETEST_OPTIONS_SCRIPT_PATH` to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,7 @@ WEBPAGETEST_OPTIONS_MOBILE=1
 WEBPAGETEST_OPTIONS_MOBILE_DEVICE=Pixel
 ##  Set to 1 to have a lighthouse test also performed (Chrome-only, wptagent agents only)
 WEBPAGETEST_OPTIONS_LIGHTHOUSE=1
+## WebPagetest Scripting Option
+## Set file path to scripting file
+## https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/scripting
+# WEBPAGETEST_OPTIONS_SCRIPT_PATH=./script.txt

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ So, you can set **Time Trigger** by the following function.
   - You can set time trigger like cron
   - By default, it is per 30 minutes
 
-### Setup  at first time 
+### Setup at first time 
 
 0. Visit your google spread sheet
 1. Invoke "Update column titles" from spread sheet's menu
@@ -158,6 +158,35 @@ So, you can set **Time Trigger** by the following function.
 After that, `gas-webpagetest` run tests per 30 minutes and put the results to your spreadsheet.
 
 ![spread-sheet-example.png](docs/img/spread-sheet-example.png)
+
+## Additional: WebPagetest script
+
+If you want to use scripting for WebPagetest, uncomment `WEBPAGETEST_OPTIONS_SCRIPT_PATH` in `.env` and write script in `script.txt`.
+
+- <https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/scripting>
+
+```
+## WebPagetest Scripting Option
+## Set file path to scripting file
+## https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/scripting
+WEBPAGETEST_OPTIONS_SCRIPT_PATH=./script.txt
+```
+
+Example: `script.txt`
+
+```
+logData	0
+
+// bring up the login screen
+navigate	http://webmail.aol.com
+
+logData	1
+
+// log in
+setValue	name=loginId	someuser@aol.com
+setValue	name=password	somepassword
+submitForm	name=AOLLoginForm
+```
 
 ## Optional: Visualization
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js": "^2.5.7",
     "cpx": "^1.5.0",
     "cross-spawn": "^6.0.5",
+    "dotenv": "^6.0.0",
     "dotenv-webpack": "^1.5.7",
     "gas-webpack-plugin": "^0.3.0",
     "husky": "^0.14.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,23 @@ const Dotenv = require('dotenv-webpack')
 const GasPlugin = require('gas-webpack-plugin')
 const webpack = require('webpack')
 const fs = require('fs')
-const SCRIPT_FILE_PATH = path.join(__dirname, 'script.txt')
-const WEBPAGETEST_OPTIONS_SCRIPT_CODE = fs.existsSync(SCRIPT_FILE_PATH)
-  ? fs.readFileSync(SCRIPT_FILE_PATH, 'utf-8')
-  : undefined
+const dotenv = require('dotenv')
+const getWebPagetestCode = () => {
+  const result = dotenv.config()
+  if (result.error) {
+    throw result.error
+  }
+  const WEBPAGETEST_OPTIONS_SCRIPT_PATH = result.parsed.WEBPAGETEST_OPTIONS_SCRIPT_PATH
+  if (!WEBPAGETEST_OPTIONS_SCRIPT_PATH) {
+    return
+  }
+  const SCRIPT_FILE_PATH = path.resolve(__dirname, WEBPAGETEST_OPTIONS_SCRIPT_PATH)
+  console.log(SCRIPT_FILE_PATH)
+  if (!fs.existsSync(SCRIPT_FILE_PATH)) {
+    return
+  }
+  return fs.readFileSync(SCRIPT_FILE_PATH, 'utf-8')
+}
 
 module.exports = {
   mode: 'none',
@@ -32,9 +45,7 @@ module.exports = {
   plugins: [
     new Dotenv(),
     new webpack.DefinePlugin({
-      'process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE': JSON.stringify(
-        WEBPAGETEST_OPTIONS_SCRIPT_CODE
-      ),
+      'process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE': JSON.stringify(getWebPagetestCode()),
     }),
     new GasPlugin(),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,10 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
+dotenv@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
+
 dotf@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dotf/-/dotf-1.0.3.tgz#d22131d85a0f60f432bd906a7a8bed2a52f674c4"


### PR DESCRIPTION
`WEBPAGETEST_OPTIONS_SCRIPT_PATH=./script.txt` という感じで任意のパスを指定できるようにしました。(デフォルトはコメントアウトしてるので単純に無効化されています)

fix #22 