### PR TITLE
feat: Add REPORT_NETWORK_ERROR option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ RUN_TEST_URL=https://example.com
 RUN_TEST_INTERVAL=30m
 # Sheet name to record
 SHEET_NAME=Sheet1
+# If it is 0, suppress Network Error report from Google Apps Scripts
+REPORT_NETWORK_ERROR=1
 
 # WebPagetest Options
 # https://sites.google.com/a/webpagetest.org/docs/advanced-features/webpagetest-restful-apis

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -33,6 +33,25 @@ class Utils {
   }
 
   /**
+   * Parse value as boolean number
+   * true: 1
+   * false: 0
+   */
+  public static parseBooleanNumberValue(value?: string): boolean {
+    if (!value) {
+      return false
+    }
+    if (value !== '0' && value !== '1') {
+      throw new Error(`This value should be "0" or "1": ${value}`)
+    }
+    const numberValue = Number(value)
+    if (isNaN(numberValue)) {
+      throw new Error(`This value can not be parsed as number: ${value}`)
+    }
+    return numberValue === 1
+  }
+
+  /**
    * Parse time formatted value and return { type, value }
    * Accept format: <value><unit>
    *   - <value>: number

--- a/src/WebPagetest.ts
+++ b/src/WebPagetest.ts
@@ -51,44 +51,61 @@ class WebPagetest {
    *
    * @return {} testId
    */
-  public runTest(url: string, options?: Options): string {
-    const requestURL = this.generateRunTestURL(url, options)
-    const {
-      data: { testId },
-    } = Utils.fetch(requestURL)
-
-    return testId
+  public runTest(url: string, options?: Options): string | Error {
+    try {
+      const requestURL = this.generateRunTestURL(url, options)
+      const response = Utils.fetch(requestURL)
+      const {
+        data: { testId },
+      } = response
+      return testId
+    } catch (error) {
+      return error
+    }
   }
 
-  public getTestStatus(testId: string): number {
-    const {
-      data: { statusCode },
-    } = Utils.fetch(this.generateTestStatusURL(testId))
-
-    return statusCode
+  public getTestStatus(testId: string): number | Error {
+    try {
+      const response = Utils.fetch(this.generateTestStatusURL(testId))
+      const {
+        data: { statusCode },
+      } = response
+      return statusCode
+    } catch (error) {
+      return error
+    }
   }
 
   /**
    * テスト結果取得
    *
-   * @param {type}    testId - this is the parameter testId
-   *
-   * @return {Object} responsedata
+   * @param testId - this is the parameter testId
+   * @returns {string[]|Error} response data
    */
   public getTestResults(testId) {
     // 空文字は無視する
     if (testId.length === 0) {
-      return new Array(this.countOfResults()).fill('')
+      return this.createEmptyTestResults()
     }
 
     const statusCode = this.getTestStatus(testId)
+    if (statusCode instanceof Error) {
+      return statusCode // Return Error object
+    }
     if (statusCode !== 200) {
-      return new Array(this.countOfResults()).fill('')
+      return this.createEmptyTestResults()
     }
 
     const requestURL = this.generateTestResultsURL(testId)
     const response = Utils.fetch(requestURL)
     return this.generateTestResultValues(this.convertWebPageResponseToResult(response))
+  }
+
+  /**
+   * Return empty row data
+   */
+  public createEmptyTestResults() {
+    return new Array(this.countOfResults()).fill('')
   }
 
   public test = this.runTest

--- a/src/__tests__/Utils.test.ts
+++ b/src/__tests__/Utils.test.ts
@@ -19,6 +19,32 @@ describe('Utils', () => {
       }).toThrow()
     })
   })
+  describe('parseBooleanNumberValue', () => {
+    it('should return false if value is undefined', () => {
+      expect(Utils.parseBooleanNumberValue()).toBe(false)
+    })
+    it('should return false if value is "0"', () => {
+      expect(Utils.parseBooleanNumberValue('0')).toBe(false)
+    })
+    it('should return true if value is "1"', () => {
+      expect(Utils.parseBooleanNumberValue('1')).toBe(true)
+    })
+
+    it('should throw error if value can not be acceptable value', () => {
+      expect(() => {
+        Utils.parseBooleanNumberValue('-1')
+      }).toThrow()
+      expect(() => {
+        Utils.parseBooleanNumberValue('2')
+      }).toThrow()
+      expect(() => {
+        Utils.parseBooleanNumberValue('10')
+      }).toThrow()
+      expect(() => {
+        Utils.parseBooleanNumberValue('a')
+      }).toThrow()
+    })
+  })
   describe('parseTimeFormat', () => {
     it('should return { type: HOUR } when pass 1h', () => {
       expect(Utils.parseTimeFormat('1h')).toEqual({

--- a/src/gas.d.ts
+++ b/src/gas.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
     RUN_TEST_URL?: string
     RUN_TEST_INTERVAL?: string
     SHEET_NAME?: string
+    NETWORK_ERROR_REPORT?: string
     WEBPAGETEST_OPTIONS_RUNS?: string
     WEBPAGETEST_OPTIONS_LOCATION?: string
     WEBPAGETEST_OPTIONS_FVONLY?: string

--- a/src/runTest.ts
+++ b/src/runTest.ts
@@ -24,21 +24,30 @@ export const runTest = (): void => {
   const mobileDevice = process.env.WEBPAGETEST_OPTIONS_MOBILE_DEVICE
   const lighthouse = Utils.parseNumberValue(process.env.WEBPAGETEST_OPTIONS_LIGHTHOUSE)
   const script = process.env.WEBPAGETEST_OPTIONS_SCRIPT_CODE
+  const enabledNetworkErrorReport = Utils.parseBooleanNumberValue(process.env.NETWORK_ERROR_REPORT)
   const wpt = new WebPagetest(key)
-  const testId = wpt.test(url, {
-    runs,
-    location,
-    fvonly,
-    video,
-    // format: JSON for getTestResults
-    format: 'JSON',
-    noOptimization,
-    mobile,
-    mobileDevice,
-    lighthouse,
-    script,
-  })
-
+  let testId
+  try {
+    testId = wpt.test(url, {
+      runs,
+      location,
+      fvonly,
+      video,
+      // format: JSON for getTestResults
+      format: 'JSON',
+      noOptimization,
+      mobile,
+      mobileDevice,
+      lighthouse,
+      script,
+    })
+  } catch (error) {
+    Logger.log('Failed runTest', error)
+    if (enabledNetworkErrorReport) {
+      throw new error
+    }
+    return
+  }
   const activeSpreadsheet = SpreadsheetApp.getActiveSpreadsheet()
   if (!activeSpreadsheet) {
     throw new Error('Not found active spreadsheet')


### PR DESCRIPTION
If REPORT_NETWORK_ERROR=1, report Network error(exception error) – It is default.
If REPORT_NETWORK_ERROR=0, suppress Network error.

Network error is all `UrlFetchApp.fetch` exceptions.

For example:

- Address unavailable (It is bug of GAS?) https://issuetracker.google.com/issues/36758958
- Server Error

📝 Why does not retry?

Retry feature confuse API count of WebPageTest.
Probably, One retry consume one API count of WebPageTest when server is something wrong.

## Related Issue

Fix #20 