### PR TITLE
fix(getLastRow): get last non-empty cell

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -4,11 +4,17 @@ class Utils {
     return JSON.parse(response.getContentText())
   }
 
-  public static getLastRow(sheet, row) {
-    return sheet
-      .getRange(`${row}:${row}`)
-      .getValues()
-      .filter(String).length
+  public static getLastRow(sheet, column) {
+    const targetColumnRange = sheet.getRange(`${column}:${column}`)
+    const lowermostCell = sheet.getRange(
+      targetColumnRange.getLastRow(),
+      targetColumnRange.getColumn()
+    )
+    if (lowermostCell.getValue()) {
+      return lowermostCell.getRow()
+    } else {
+      return lowermostCell.getNextDataCell(SpreadsheetApp.Direction.UP).getRow()
+    }
   }
 
   public static transform(value, digits = 2) {


### PR DESCRIPTION
## 問題

#32 と同様に、テスト結果が消えてしまいます。

## 原因

`completedTimeStamp`が何らかの原因で歯抜けになっている場合に、`Utils.getLastRow`が正しく最終行を取得できなくなってしまうようです。

| No. | testId | completedTimeStamp | ... |
| --- | --- | --- | --- |
| 1 | hoge | 1545294895 | ... |
| 2 | fuga | | ... |
| 3 | piyo | | ... |
| 4 | mugi | 1545294896 | ... |
| 5 | kome | | ... |

とあった場合、最終行は4となるはずです。
しかし2となるため、`piyo`と`mugi`と`kome`のデータを取りに行ってしまい、
結果的に`mugi`が上書きされてしまう（Test not foundの場合、消えてしまう）ようです。

## やったこと

- `Utils.getLastRow`を`getNextDataCell`を使う形で書き換えました。
- 引数として渡しているのはcolumnのようなので、引数名をrow -> columnに修正しています。